### PR TITLE
test(sobel): add magnitude clamping and diagonal edge tests

### DIFF
--- a/silvestre-core/src/filters/sobel.rs
+++ b/silvestre-core/src/filters/sobel.rs
@@ -278,4 +278,47 @@ mod tests {
             "gy at middle row should be ~0"
         );
     }
+
+    #[test]
+    fn magnitude_clamped_at_max_contrast_edge() {
+        // A sharp black-to-white step (0 → 255) produces a pre-clamp gradient
+        // magnitude well above 255. Verify the output is clamped to exactly 255
+        // and that the type conversion doesn't saturate silently at the wrong value.
+        #[rustfmt::skip]
+        let pixels = vec![
+            0,   0,   255, 255,
+            0,   0,   255, 255,
+            0,   0,   255, 255,
+            0,   0,   255, 255,
+        ];
+        let img = gray_image(4, 4, pixels);
+        let out = SobelFilter::new().apply(&img).unwrap();
+        let max = *out.pixels().iter().max().unwrap();
+        assert_eq!(max, 255, "edge pixels at full contrast should be clamped to 255");
+    }
+
+    #[test]
+    fn diagonal_edge_activates_both_gradients() {
+        // A diagonal step (upper-left dark, lower-right bright) should
+        // produce non-zero responses in both Gx and Gy at the center pixel.
+        #[rustfmt::skip]
+        let pixels = vec![
+            0,   0,   0,
+            0,   128, 255,
+            0,   255, 255,
+        ];
+        let img = gray_image(3, 3, pixels);
+        let (gx, gy) = sobel_gradients(&img, BorderMode::Clamp);
+        let center = 4; // row 1, col 1
+        assert!(
+            gx[center].abs() > 1.0,
+            "gx at diagonal edge center should be non-zero: {}",
+            gx[center]
+        );
+        assert!(
+            gy[center].abs() > 1.0,
+            "gy at diagonal edge center should be non-zero: {}",
+            gy[center]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- The `SobelFilter` (3×3 Gx/Gy kernels, gradient magnitude, `pub(crate) sobel_gradients` for Canny) was already implemented in `silvestre-core/src/filters/sobel.rs` as part of the Canny prerequisite (#46)
- All acceptance criteria were structurally met but two coverage gaps existed: no test verified gradient magnitude clamping to 255, and no test validated diagonal edge responses in both Gx and Gy
- Added `magnitude_clamped_at_max_contrast_edge`: applies the filter to a full-contrast (0→255) vertical step and asserts the max output pixel equals 255, confirming pre-clamp magnitudes above 255 are handled correctly
- Added `diagonal_edge_activates_both_gradients`: applies `sobel_gradients` to a diagonal intensity step and asserts both `gx` and `gy` are non-zero at the center pixel

Closes #15

## Test plan

- [x] `cargo build --workspace` — builds cleanly (1 pre-existing unrelated warning in `histogram.rs`)
- [x] `cargo test -p silvestre-core` — all 169 unit tests + 20 doc tests pass
- [x] `magnitude_clamped_at_max_contrast_edge` passes — max output is 255
- [x] `diagonal_edge_activates_both_gradients` passes — both Gx and Gy non-zero at diagonal edge
- [x] CodeRabbit review: no findings