### PR TITLE
docs: complete API docs and per-platform README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,137 +2,292 @@
 
 Cross-platform image processing library written in Rust.
 
-Run the same filters natively on **CLI**, **Android**, **iOS**, **Flutter**, and **WebAssembly** from a single codebase.
+Run the same filters natively on the **CLI**, on **Android** and **iOS** via
+**Flutter**, and in the **browser** via **WebAssembly** — all from a single pure
+Rust core.
 
-> Spiritual successor to an old Java/C# college project, rebuilt from scratch with a modern Rust core.
+> Spiritual successor to an old Java/C# college project, rebuilt from scratch
+> with a modern Rust core.
 
 ## Architecture
 
 ```text
- CLI    Flutter    iOS     Web    Android
-  │    (dart:ffi)  (C FFI) (WASM) (JNI/NDK)
-  │        │         │       │       │
-  └────────┴─────────┴───────┴───────┘
-                     │
-            silvestre-ffi (C ABI)
-                     │
-            silvestre-core (Pure Rust)
+   CLI        Flutter          Web          C / C++ / Swift / JNI
+ (native)   (dart:ffi)        (WASM)              (C ABI)
+    │            │               │                    │
+    │      silvestre_flutter  silvestre-wasm    silvestre-ffi
+    │        (frb bridge)    (wasm-bindgen)      (C ABI, cbindgen)
+    │            │               │                    │
+    └────────────┴───────────────┴────────────────────┘
+                             │
+                    silvestre-core  (pure Rust, no platform deps)
 ```
 
-**silvestre-core** contains all image processing logic as a pure Rust library. **silvestre-ffi** exposes it through a C ABI so every platform can consume it via its native FFI mechanism.
+**silvestre-core** holds every image-processing operation as a pure Rust
+library with no platform dependencies. Each platform crate is a thin binding
+layer over it:
+
+- **silvestre-cli** — an interactive terminal UI (ratatui).
+- **silvestre-ffi** — a stable C ABI (with a `cbindgen`-generated header) for
+  C/C++, Swift, and JNI consumers.
+- **silvestre-wasm** — `wasm-bindgen` bindings for the browser.
+- **silvestre_flutter** — a Flutter plugin using `flutter_rust_bridge`.
 
 ## Features
 
-### Filters
+| Category | Operations |
+|---|---|
+| **Filters** | Box blur, Gaussian blur, Median, Sharpen, Sobel, Canny edge detection |
+| **Effects** | Grayscale, Sepia, Invert, Brightness, Contrast |
+| **Transforms** | Resize (nearest-neighbor & bilinear), Rotate, Mirror/Flip, Crop |
+| **Analysis** | Per-channel & luminance histograms with statistics |
+| **Image I/O** | Load & save PNG, JPEG, BMP via the [`image`](https://crates.io/crates/image) crate |
 
-Canny edge detection, Median, Gaussian blur, Sobel, Sharpen, Box blur
-
-### Effects
-
-Grayscale, Sepia, Invert, Brightness, Contrast
-
-### Transforms
-
-Resize (nearest-neighbor & bilinear), Rotate, Mirror/Flip, Crop
-
-### Analysis
-
-Histogram computation, Image statistics
-
-### Image I/O
-
-PNG, JPEG, BMP, WebP &mdash; load and save via the [`image`](https://crates.io/crates/image) crate
-
-## Project Structure
+## Project structure
 
 ```text
 silvestre/
-├── silvestre-core/        # Pure Rust image processing library
-├── silvestre-ffi/         # C ABI foreign function interface
-├── silvestre-cli/         # Command-line tool
-├── silvestre-wasm/        # WebAssembly bindings (planned)
-├── silvestre-flutter/     # Flutter package via flutter_rust_bridge (planned)
-└── tests/
-    └── fixtures/          # Test images
+├── silvestre-core/     # Pure Rust image processing library
+├── silvestre-ffi/      # C ABI foreign function interface (cbindgen header)
+├── silvestre-cli/      # Interactive terminal UI (ratatui)
+├── silvestre-wasm/     # WebAssembly bindings (wasm-bindgen) + web demo
+├── silvestre_flutter/  # Flutter plugin via flutter_rust_bridge + example app
+└── tests/fixtures/     # Test images
 ```
 
-## Getting Started
+## Quick start
 
 ### Prerequisites
 
-- [Rust](https://rustup.rs/) 1.70+
+- [Rust](https://rustup.rs/) 1.70+ (`cargo`, `rustc`)
+- Platform extras, as needed:
+  - WASM: `rustup target add wasm32-unknown-unknown` and
+    [wasm-pack](https://rustwasm.github.io/wasm-pack/)
+  - Flutter: the [Flutter SDK](https://docs.flutter.dev/get-started/install)
 
-### Build
+Build and test the whole workspace:
 
 ```bash
 cargo build --workspace
-```
-
-### Test
-
-```bash
 cargo test --workspace
 ```
 
-### CLI Usage
+---
 
-```bash
-# Apply a filter
-cargo run -p silvestre-cli -- apply median --input photo.jpg --output out.jpg
+### 1. Rust (`silvestre-core`)
 
-# List available filters
-cargo run -p silvestre-cli -- list
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+silvestre-core = { git = "https://github.com/enzoftware/silvestre" }
 ```
 
-## Rust API
+Every operation implements the [`Filter`] trait and returns a **new** image,
+leaving the input untouched, so filters compose cleanly:
 
 ```rust
-use silvestre_core::{SilvestreImage, Filter};
+use silvestre_core::effects::{BrightnessFilter, GrayscaleFilter};
+use silvestre_core::filters::{Filter, GaussianFilter};
+use silvestre_core::SilvestreImage;
 
-// Load an image
-let img = SilvestreImage::load("photo.png")?;
+fn main() -> Result<(), silvestre_core::SilvestreError> {
+    // Load from disk (PNG, JPEG, or BMP).
+    let image = SilvestreImage::load("photo.png")?;
 
-// Apply a filter (once implemented)
-// let result = MedianFilter::new(3).apply(&img)?;
+    // Apply filters in sequence.
+    let result = GrayscaleFilter.apply(&image)?;
+    let result = BrightnessFilter::new(30).apply(&result)?;
+    let result = GaussianFilter::new(2.0)?.apply(&result)?;
 
-// Save the result
-// result.save("output.png")?;
+    // Save the result (format inferred from the extension).
+    result.save("output.png")?;
+    Ok(())
+}
 ```
 
-## Platform Targets
+Full API docs: `cargo doc --no-deps -p silvestre-core --open`.
 
-| Platform | Mechanism | Status |
-|---|---|---|
-| CLI | Native binary | In progress |
-| WebAssembly | `wasm-bindgen` + `wasm-pack` | Planned |
-| Flutter | `flutter_rust_bridge` v2 | Planned |
-| Android | Rust &rarr; C ABI &rarr; JNI (NDK) | Planned |
-| iOS | Rust &rarr; C ABI &rarr; Swift interop | Planned |
+---
 
-## Tech Stack
+### 2. CLI (`silvestre-cli`)
+
+An interactive terminal UI for browsing filters and building filter pipelines:
+
+```bash
+cargo run -p silvestre-cli
+```
+
+Use the arrow keys to navigate, `Space` to toggle filters in the pipeline, and
+follow the on-screen hints to load an image and export the result.
+
+---
+
+### 3. WebAssembly (`silvestre-wasm`)
+
+Build the WASM package:
+
+```bash
+cd silvestre-wasm
+wasm-pack build --target web --out-dir pkg
+```
+
+Then use it from JavaScript/TypeScript in the browser:
+
+```ts
+import init, { WasmImage } from "silvestre-wasm";
+
+await init(); // call once before using WasmImage
+
+// Load from file bytes (e.g. a fetch or <input type="file">).
+const bytes = new Uint8Array(await (await fetch("/photo.png")).arrayBuffer());
+const image = WasmImage.loadFromBytes(bytes);
+
+// Filters chain; each call returns a new WasmImage.
+const result = image
+  .applyFilter("grayscale", {})
+  .applyFilter("brightness", { delta: 20 })
+  .applyFilter("gaussian", { sigma: 2.0 });
+
+// Render to a <canvas>…
+const canvas = document.querySelector<HTMLCanvasElement>("#preview");
+const context = canvas?.getContext("2d");
+if (!context) throw new Error("2D canvas context unavailable");
+const imageData = result.toImageData();
+context.putImageData(imageData, 0, 0);
+
+// …or export encoded bytes.
+const png = result.toBytes("png"); // Uint8Array
+```
+
+A complete Vite demo lives in [`silvestre-wasm/www`](silvestre-wasm/www). See the
+[crate README](silvestre-wasm/README.md) for the full JS API.
+
+---
+
+### 4. Flutter (`silvestre_flutter`)
+
+Add the plugin to your `pubspec.yaml`, then call `Silvestre.init()` once before
+using the API. Every operation runs in Rust on a background isolate, so the
+async Dart API keeps the UI responsive:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:silvestre_flutter/silvestre_flutter.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Silvestre.init();
+
+  final image = await SilvestreImage.fromPath('/path/to/photo.png');
+
+  // Convenience methods…
+  final gray = await image.grayscale();
+  // …or the generic entry point with snake_case names + params.
+  final blurred = await image.applyFilter('gaussian', params: {'sigma': 2.0});
+
+  await blurred.save('/path/to/output.png');
+}
+```
+
+The plugin ships a full Bloc-based example app (camera capture, gallery save,
+live histogram, before/after slider) in
+[`silvestre_flutter/example`](silvestre_flutter/example). See the
+[plugin README](silvestre_flutter/README.md) for the full Dart API.
+
+---
+
+### 5. C ABI (`silvestre-ffi`)
+
+Building the crate regenerates the C header at
+[`silvestre-ffi/include/silvestre.h`](silvestre-ffi/include/silvestre.h) via
+`cbindgen`:
+
+```bash
+cargo build -p silvestre-ffi   # produces libsilvestre_ffi + silvestre.h
+```
+
+Consume it from C (or any language with C interop — Swift, JNI, etc.):
+
+```c
+#include <stdio.h>
+#include "silvestre.h"
+
+SilvestreImage *img = silvestre_image_load("photo.png");
+if (img == NULL) {
+    fprintf(stderr, "load failed: %s\n", silvestre_last_error());
+    return 1;
+}
+
+// Apply a filter by name; parameters are a JSON string (or NULL for none).
+if (silvestre_apply_filter(img, "gaussian", "{\"sigma\": 2.0}") != 0) {
+    fprintf(stderr, "filter failed: %s\n", silvestre_last_error());
+    silvestre_image_free(img);
+    return 1;
+}
+
+// NULL format → infer from the file extension.
+if (silvestre_image_save(img, "output.png", NULL) != 0) {
+    fprintf(stderr, "save failed: %s\n", silvestre_last_error());
+    silvestre_image_free(img);
+    return 1;
+}
+
+silvestre_image_free(img);
+```
+
+Error handling is thread-local: functions return `0` on success and `-1` on
+error; call `silvestre_last_error()` for the message.
+
+## Documentation
+
+Generate the full Rust API documentation for the workspace:
+
+```bash
+cargo doc --no-deps --workspace --open
+```
+
+All public items are documented, and inline examples are verified by
+`cargo test --doc`.
+
+## Contributing
+
+Contributions are welcome! To get started:
+
+1. **Fork and branch.** Create a feature branch from `main`
+   (e.g. `feat/my-filter`).
+2. **Keep the core pure.** New image-processing logic belongs in
+   `silvestre-core` behind the [`Filter`] trait, not in a platform crate.
+   Platform crates should only adapt types and delegate to the core.
+3. **Document public items.** Every crate enforces `#![warn(missing_docs)]`;
+   add a `///` doc comment (with a `# Examples` block where it helps) to any new
+   public type or function.
+4. **Test thoroughly.** Cover happy paths, edge cases, and error conditions.
+   Doc examples double as tests.
+5. **Verify before opening a PR:**
+
+   ```bash
+   cargo build --workspace
+   cargo test --workspace
+   cargo test --doc
+   cargo doc --no-deps --workspace   # must be warning-free
+   cargo fmt --all
+   cargo clippy --workspace -- -D warnings
+   ```
+
+6. **Open a PR** describing the change and referencing any related issue.
+
+## Tech stack
 
 | Component | Technology |
 |---|---|
 | Core library | Rust |
 | Image codec | [`image`](https://crates.io/crates/image) 0.25 |
 | Error handling | [`thiserror`](https://crates.io/crates/thiserror) 2 |
-| CLI | [`clap`](https://crates.io/crates/clap) 4 |
+| CLI | [`ratatui`](https://crates.io/crates/ratatui) + [`crossterm`](https://crates.io/crates/crossterm) |
 | C header gen | [`cbindgen`](https://crates.io/crates/cbindgen) |
-| WASM | `wasm-bindgen` |
-| Flutter bridge | `flutter_rust_bridge` v2 |
-| Testing | `cargo test` + `proptest` |
-| Benchmarks | `criterion` |
-
-## Roadmap
-
-See [PLAN.md](PLAN.md) for the full implementation plan.
-
-1. **Core library** &mdash; image types, filters, effects, transforms, analysis
-2. **CLI tool** &mdash; apply filters from the command line
-3. **C FFI layer** &mdash; stable ABI for platform bindings
-4. **WebAssembly** &mdash; run in the browser
-5. **Flutter package** &mdash; Android, iOS, and desktop via `flutter_rust_bridge`
-6. **Polish & release** &mdash; CI, docs, publish to crates.io / pub.dev / npm
+| WASM | [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen) + `wasm-pack` |
+| Flutter bridge | [`flutter_rust_bridge`](https://pub.dev/packages/flutter_rust_bridge) v2 |
 
 ## License
 

--- a/silvestre-core/src/analysis/mod.rs
+++ b/silvestre-core/src/analysis/mod.rs
@@ -1,4 +1,7 @@
-// Image analysis tools.
+//! Image analysis tools.
+//!
+//! Currently provides per-channel [`Histogram`] computation for inspecting the
+//! tonal distribution of an image.
 
 pub mod histogram;
 

--- a/silvestre-core/src/effects/mod.rs
+++ b/silvestre-core/src/effects/mod.rs
@@ -1,4 +1,8 @@
-// Color and pixel-level effects.
+//! Color and pixel-level effects.
+//!
+//! These filters operate on each pixel independently (no spatial neighborhood):
+//! [`BrightnessFilter`], [`ContrastFilter`], [`GrayscaleFilter`],
+//! [`InvertFilter`], and [`SepiaFilter`].
 
 pub mod brightness;
 pub mod contrast;

--- a/silvestre-core/src/error.rs
+++ b/silvestre-core/src/error.rs
@@ -36,7 +36,7 @@ pub enum SilvestreError {
     },
 
     /// Pixel coordinates fell outside the image bounds.
-    #[error("pixel coordinates out of bounds: ({x}, {y}) in {width}x{height} image.")]
+    #[error("pixel coordinates out of bounds: ({x}, {y}) in {width}x{height} image")]
     OutOfBounds {
         /// The out-of-range x coordinate.
         x: u32,
@@ -47,7 +47,6 @@ pub enum SilvestreError {
         /// Image height the coordinate was checked against.
         height: u32,
     },
-
     /// An operation does not support the image's color space.
     #[error("unsupported color space: {0:?}")]
     UnsupportedColorSpace(crate::ColorSpace),

--- a/silvestre-core/src/error.rs
+++ b/silvestre-core/src/error.rs
@@ -1,34 +1,68 @@
 use thiserror::Error;
 
 /// Errors that can occur during image processing.
+///
+/// Every fallible operation in silvestre returns [`crate::Result`], which wraps
+/// this type. Variants carry enough context (dimensions, offsets, expected vs.
+/// actual sizes) to diagnose the failure without additional logging.
 #[derive(Debug, Error)]
 pub enum SilvestreError {
+    /// An underlying I/O operation failed (e.g. reading or writing a file).
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// The `image` crate could not decode or encode the image data.
     #[error("image decoding error: {0}")]
     ImageDecode(#[from] image::ImageError),
 
+    /// The requested `width`×`height` is invalid, typically because the pixel
+    /// count overflows `usize`.
     #[error("invalid dimensions: {width}x{height}")]
-    InvalidDimensions { width: u32, height: u32 },
-
-    #[error("raw pixel buffer size mismatch: expected {expected} bytes, got {got}")]
-    BufferSizeMismatch { expected: usize, got: usize },
-
-    #[error("pixel coordinates out of bounds: ({x}, {y}) in {width}x{height} image.")]
-    OutOfBounds {
-        x: u32,
-        y: u32,
+    InvalidDimensions {
+        /// Requested image width in pixels.
         width: u32,
+        /// Requested image height in pixels.
         height: u32,
     },
 
+    /// A raw pixel buffer did not match the size implied by the image's
+    /// dimensions and color space.
+    #[error("raw pixel buffer size mismatch: expected {expected} bytes, got {got}")]
+    BufferSizeMismatch {
+        /// Number of bytes the buffer was expected to contain.
+        expected: usize,
+        /// Number of bytes the buffer actually contained.
+        got: usize,
+    },
+
+    /// Pixel coordinates fell outside the image bounds.
+    #[error("pixel coordinates out of bounds: ({x}, {y}) in {width}x{height} image.")]
+    OutOfBounds {
+        /// The out-of-range x coordinate.
+        x: u32,
+        /// The out-of-range y coordinate.
+        y: u32,
+        /// Image width the coordinate was checked against.
+        width: u32,
+        /// Image height the coordinate was checked against.
+        height: u32,
+    },
+
+    /// An operation does not support the image's color space.
     #[error("unsupported color space: {0:?}")]
     UnsupportedColorSpace(crate::ColorSpace),
 
+    /// A pixel value had a different number of channels than the image's color
+    /// space requires.
     #[error("channel count mismatch: expected {expected}, got {got}")]
-    ChannelMismatch { expected: usize, got: usize },
+    ChannelMismatch {
+        /// Number of channels the color space requires.
+        expected: usize,
+        /// Number of channels supplied.
+        got: usize,
+    },
 
+    /// A caller-supplied parameter was invalid; the message describes why.
     #[error("{0}")]
     InvalidParameter(String),
 }

--- a/silvestre-core/src/filters/convolution.rs
+++ b/silvestre-core/src/filters/convolution.rs
@@ -186,16 +186,19 @@ impl Kernel {
         Self::square(values, size)
     }
 
+    /// Kernel width in taps.
     #[must_use]
     pub fn width(&self) -> usize {
         self.width
     }
 
+    /// Kernel height in taps.
     #[must_use]
     pub fn height(&self) -> usize {
         self.height
     }
 
+    /// The kernel weights in row-major order (`width * height` entries).
     #[must_use]
     pub fn values(&self) -> &[f32] {
         &self.values
@@ -259,11 +262,13 @@ impl SeparableKernel {
         })
     }
 
+    /// The horizontal (row) component of the separable kernel.
     #[must_use]
     pub fn horizontal(&self) -> &[f32] {
         &self.horizontal
     }
 
+    /// The vertical (column) component of the separable kernel.
     #[must_use]
     pub fn vertical(&self) -> &[f32] {
         &self.vertical

--- a/silvestre-core/src/filters/mod.rs
+++ b/silvestre-core/src/filters/mod.rs
@@ -27,6 +27,21 @@ use crate::{Result, SilvestreImage};
 /// A filter takes an immutable reference to a [`SilvestreImage`] and produces
 /// a new image, leaving the original untouched. This makes filters trivially
 /// composable: `gaussian.apply(&sobel.apply(&img)?)?`.
+///
+/// # Examples
+///
+/// ```
+/// use silvestre_core::effects::InvertFilter;
+/// use silvestre_core::{ColorSpace, Filter, SilvestreImage};
+///
+/// let image = SilvestreImage::new(vec![10, 20, 30], 1, 1, ColorSpace::Rgb)?;
+/// let inverted = InvertFilter.apply(&image)?;
+///
+/// assert_eq!(inverted.pixels(), &[245, 235, 225]);
+/// // The original is untouched.
+/// assert_eq!(image.pixels(), &[10, 20, 30]);
+/// # Ok::<_, silvestre_core::SilvestreError>(())
+/// ```
 pub trait Filter: Send + Sync {
     /// Apply this filter to the given image, returning a new image.
     fn apply(&self, image: &SilvestreImage) -> Result<SilvestreImage>;

--- a/silvestre-core/src/image.rs
+++ b/silvestre-core/src/image.rs
@@ -1,10 +1,16 @@
 use crate::{Result, SilvestreError};
 
 /// Supported color space representations.
+///
+/// The variant determines how many bytes each pixel occupies; see
+/// [`ColorSpace::channels`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorSpace {
+    /// Red, green, blue, and alpha — 4 bytes per pixel.
     Rgba,
+    /// Red, green, and blue — 3 bytes per pixel.
     Rgb,
+    /// Single luminance channel — 1 byte per pixel.
     Grayscale,
 }
 
@@ -34,6 +40,20 @@ impl SilvestreImage {
     ///
     /// Returns an error if the buffer length does not match
     /// `width * height * color_space.channels()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use silvestre_core::{ColorSpace, SilvestreImage};
+    ///
+    /// // A 2x1 RGB image needs 2 * 1 * 3 = 6 bytes.
+    /// let image = SilvestreImage::new(vec![0; 6], 2, 1, ColorSpace::Rgb)?;
+    /// assert_eq!(image.width(), 2);
+    ///
+    /// // A buffer of the wrong size is rejected.
+    /// assert!(SilvestreImage::new(vec![0; 5], 2, 1, ColorSpace::Rgb).is_err());
+    /// # Ok::<_, silvestre_core::SilvestreError>(())
+    /// ```
     pub fn new(pixels: Vec<u8>, width: u32, height: u32, color_space: ColorSpace) -> Result<Self> {
         let expected = (width as usize)
             .checked_mul(height as usize)
@@ -68,16 +88,19 @@ impl SilvestreImage {
         }
     }
 
+    /// Image width in pixels.
     #[must_use]
     pub fn width(&self) -> u32 {
         self.width
     }
 
+    /// Image height in pixels.
     #[must_use]
     pub fn height(&self) -> u32 {
         self.height
     }
 
+    /// The image's [`ColorSpace`].
     #[must_use]
     pub fn color_space(&self) -> ColorSpace {
         self.color_space

--- a/silvestre-core/src/io.rs
+++ b/silvestre-core/src/io.rs
@@ -9,8 +9,11 @@ use crate::{ColorSpace, Result, SilvestreError, SilvestreImage};
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageFormat {
+    /// PNG — lossless compression.
     Png,
+    /// JPEG — lossy compression.
     Jpeg,
+    /// BMP — uncompressed bitmap.
     Bmp,
 }
 

--- a/silvestre-core/src/lib.rs
+++ b/silvestre-core/src/lib.rs
@@ -1,3 +1,46 @@
+//! # silvestre-core
+//!
+//! The portable image-processing engine at the heart of silvestre. It has no
+//! platform dependencies, so the same filters run natively, on the CLI, in the
+//! browser via WebAssembly, and on mobile through the FFI and Flutter bindings.
+//!
+//! ## Core concepts
+//!
+//! - [`SilvestreImage`] — an owned pixel buffer plus its dimensions and
+//!   [`ColorSpace`]. [`Filter`] operations take an image by reference and
+//!   return a new one, leaving the input untouched. (Low-level accessors such
+//!   as [`SilvestreImage::set_pixel`] and [`SilvestreImage::pixels_mut`] edit
+//!   an image in place.)
+//! - [`Filter`] — the common trait implemented by every operation. Filters are
+//!   [`Send`] + [`Sync`], so they can be shared across threads and composed
+//!   freely.
+//! - [`SilvestreError`] / [`Result`] — the error type and result alias returned
+//!   by all fallible operations.
+//!
+//! Operations are grouped into modules: [`effects`] (per-pixel color effects),
+//! [`filters`] (convolution and spatial filters), [`transform`] (geometric
+//! transforms), and [`analysis`] (histograms).
+//!
+//! ## Example
+//!
+//! Load an image conceptually, then convert it to grayscale and adjust
+//! brightness by applying filters in sequence:
+//!
+//! ```
+//! use silvestre_core::effects::{BrightnessFilter, GrayscaleFilter};
+//! use silvestre_core::{ColorSpace, Filter, SilvestreImage};
+//!
+//! // A 2x2 RGBA image (here constructed in memory; usually loaded from disk).
+//! let image = SilvestreImage::new(vec![128; 2 * 2 * 4], 2, 2, ColorSpace::Rgba)?;
+//!
+//! let gray = GrayscaleFilter.apply(&image)?;
+//! let brighter = BrightnessFilter::new(40).apply(&gray)?;
+//!
+//! assert_eq!(brighter.color_space(), ColorSpace::Grayscale);
+//! # Ok::<_, silvestre_core::SilvestreError>(())
+//! ```
+#![warn(missing_docs)]
+
 pub mod analysis;
 pub mod effects;
 pub mod filters;
@@ -13,4 +56,7 @@ pub use image::{ColorSpace, SilvestreImage};
 pub use io::ImageFormat;
 
 /// Result type alias for silvestre operations.
+///
+/// Shorthand for `std::result::Result<T, SilvestreError>` returned by every
+/// fallible operation in this crate.
 pub type Result<T> = std::result::Result<T, SilvestreError>;

--- a/silvestre-core/src/transform/mod.rs
+++ b/silvestre-core/src/transform/mod.rs
@@ -1,4 +1,7 @@
-// Geometric transformations.
+//! Geometric transformations.
+//!
+//! Operations that change pixel positions or image dimensions:
+//! [`CropFilter`], [`MirrorFilter`], [`ResizeFilter`], and [`RotateFilter`].
 
 pub mod crop;
 pub mod mirror;

--- a/silvestre-ffi/src/lib.rs
+++ b/silvestre-ffi/src/lib.rs
@@ -5,6 +5,7 @@
 //! to release images. Null pointer arguments return error codes instead of panicking.
 //!
 //! Error codes: 0 = success, -1 = error (call [`silvestre_last_error`] for details).
+#![warn(missing_docs)]
 
 use std::ffi::{c_char, CStr, CString};
 use std::path::Path;

--- a/silvestre-wasm/src/lib.rs
+++ b/silvestre-wasm/src/lib.rs
@@ -1,3 +1,11 @@
+//! WebAssembly bindings for the silvestre image processing library.
+//!
+//! Exposes [`WasmImage`], a JavaScript-friendly wrapper around
+//! [`silvestre_core::SilvestreImage`], with methods to load, filter, and export
+//! images from the browser. Build with `wasm-pack` and import the generated
+//! package; see the crate's `demo/` app for a full example.
+#![warn(missing_docs)]
+
 use wasm_bindgen::prelude::*;
 use web_sys::ImageData;
 
@@ -10,6 +18,11 @@ use silvestre_core::filters::{
 use silvestre_core::transform::{CropFilter, MirrorFilter, MirrorMode, ResizeFilter, RotateFilter};
 use silvestre_core::{ColorSpace, Filter, ImageFormat, SilvestreImage};
 
+/// Initialize the WASM module.
+///
+/// Runs automatically on module load (via `wasm_bindgen(start)`) and installs a
+/// panic hook so Rust panics surface as readable messages in the browser
+/// console.
 #[wasm_bindgen(start)]
 pub fn init() {
     console_error_panic_hook::set_once();


### PR DESCRIPTION
## Summary

Fills in the remaining public API documentation and rewrites the root README so it reflects the now-implemented platform targets (the old README still marked CLI/WASM/Flutter as "planned" and had non-working examples).

- **silvestre-core** — documented every public item that was missing docs: all `SilvestreError` variants and their fields, `ColorSpace`/`ImageFormat` variants, image and kernel accessors, and the `analysis`/`effects`/`transform` module headers (converted from `//` to `//!`). Added a crate-level overview. Locked it in with `#![warn(missing_docs)]`.
- **silvestre-ffi / silvestre-wasm** — enforced `#![warn(missing_docs)]`; added the WASM crate header and documented the `init` entry point. (FFI functions were already fully documented.)
- **Doctests** — added compilable `# Examples` to `SilvestreImage::new`, the `Filter` trait, and the crate root; verified by `cargo test --doc` (33 pass).
- **README** — accurate quick-start with working code for all five targets (Rust, CLI TUI, WASM, Flutter, C ABI), an architecture diagram, and docs + contributing sections.

Addressed CodeRabbit review feedback: narrowed the "returns a new image" / `Send + Sync` claims in the crate docs, added the missing Flutter `flutter/widgets.dart` import, made the WASM canvas example declare + null-check its context, and gave the C ABI example `#include <stdio.h>` plus proper failure propagation.

> Note: `silvestre-core`'s `filters::box_blur::tests::border_modes` fails on `main` already and is unrelated to this docs-only change; the other 309 core tests and all 33 doc tests pass.

Closes #34

## Test plan

- [x] `cargo doc --no-deps --workspace` — 0 warnings
- [x] `cargo test -p silvestre-core --doc` — 33 doc tests pass
- [x] `cargo build --workspace` — builds
- [x] Every public item in core/ffi/wasm documented (enforced via `#![warn(missing_docs)]`)
- [x] README covers all 5 platform targets with runnable examples
- [ ] Manual: skim rendered docs with `cargo doc --open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked the README with unified architecture, quick-start guides, platform-specific setup instructions, usage examples, and workspace development commands.
  - Expanded API documentation across image processing, filters, effects, transformations, analysis, image formats, errors, WebAssembly, and FFI.
  - Added examples for applying filters, creating images, handling buffers, and using platform bindings.
- **New Features**
  - Added grayscale as a supported image color space.
  - Added a dedicated error type for invalid parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->