### PR TITLE
ci: GitHub Actions building and testing all targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Cancel superseded runs on the same ref to save CI minutes.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,132 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  # ── Formatting & linting (fast, fail early) ───────────────────────────────
+  lint:
+    name: Format & Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # ── Build & test the Rust workspace on all three OSes ─────────────────────
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
+
+      - name: Build workspace
+        run: cargo build --workspace --verbose
+
+      - name: Test workspace (lib + doc)
+        run: cargo test --workspace --verbose
+
+      - name: Build silvestre-cli
+        run: cargo build -p silvestre-cli --verbose
+
+  # ── WebAssembly build ─────────────────────────────────────────────────────
+  wasm:
+    name: WASM build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: wasm-pack build
+        working-directory: silvestre-wasm
+        run: wasm-pack build --target web --out-dir pkg
+
+  # ── Flutter package: analyze, test, and native bridge build ───────────────
+  flutter:
+    name: Flutter package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: flutter
+
+      - name: Build the Rust bridge crate
+        run: cargo build -p silvestre_flutter_rust --verbose
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Resolve plugin dependencies
+        working-directory: silvestre_flutter
+        run: flutter pub get
+
+      - name: Verify formatting
+        working-directory: silvestre_flutter
+        run: dart format --set-exit-if-changed lib
+
+      - name: Analyze plugin
+        working-directory: silvestre_flutter
+        run: flutter analyze lib
+
+      - name: Resolve example dependencies
+        working-directory: silvestre_flutter/example
+        run: flutter pub get
+
+      - name: Analyze & test example
+        working-directory: silvestre_flutter/example
+        run: |
+          flutter analyze lib test
+          flutter test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -46,6 +48,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -69,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -92,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -130,3 +138,9 @@ jobs:
         run: |
           flutter analyze lib test
           flutter test
+
+      # Exercises the cargokit bridge end to end: it cross-compiles the Rust
+      # crate to the Android NDK targets and links it into the APK.
+      - name: Build example APK
+        working-directory: silvestre_flutter/example
+        run: flutter build apk --debug

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Silvestre
 
+[![CI](https://github.com/enzoftware/silvestre/actions/workflows/ci.yml/badge.svg)](https://github.com/enzoftware/silvestre/actions/workflows/ci.yml)
+
 Cross-platform image processing library written in Rust.
 
 Run the same filters natively on the **CLI**, on **Android** and **iOS** via

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,13 @@
+# Root analyzer config for the repository.
+#
+# Cargokit copies a stripped-down `build_tool` package into
+# silvestre_flutter/example/build/ during Android builds. That copy has a
+# pubspec.yaml but no analysis_options.yaml of its own, so the IDE analyzer
+# walks up and applies the example app's very_good_analysis rules to generated
+# code (surfacing lints like `discarded_futures`). Excluding build output here
+# keeps those files out of the IDE Problems panel.
+#
+# Note: `flutter analyze lib test` in CI is already scoped and unaffected.
+analyzer:
+  exclude:
+    - "**/build/**"

--- a/silvestre-cli/src/app.rs
+++ b/silvestre-cli/src/app.rs
@@ -1,9 +1,9 @@
 //! Application state and logic
 
-use std::path::PathBuf;
-use image::ImageReader;
-use silvestre_core::{SilvestreImage, ColorSpace};
 use crate::filters::{apply_named_filter, silvestre_to_dynamic, validate_filter, KNOWN_FILTERS};
+use image::ImageReader;
+use silvestre_core::{ColorSpace, SilvestreImage};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Screen {
@@ -266,16 +266,23 @@ impl App {
         };
     }
 
-    fn apply_filter_impl(&self, input_path: &str, output_path: &str, filter_name: &str, params: &str) -> Result<String, String> {
+    fn apply_filter_impl(
+        &self,
+        input_path: &str,
+        output_path: &str,
+        filter_name: &str,
+        params: &str,
+    ) -> Result<String, String> {
         let input_file = PathBuf::from(input_path);
         if !input_file.exists() {
             return Err("Input file not found!".to_string());
         }
 
         // Load image
-        let reader = ImageReader::open(&input_file)
-            .map_err(|e| format!("Failed to read image: {}", e))?;
-        let dynamic_image = reader.decode()
+        let reader =
+            ImageReader::open(&input_file).map_err(|e| format!("Failed to read image: {}", e))?;
+        let dynamic_image = reader
+            .decode()
             .map_err(|e| format!("Failed to decode image: {}", e))?;
         let rgba_image = dynamic_image.to_rgba8();
         let (width, height) = rgba_image.dimensions();
@@ -293,7 +300,10 @@ impl App {
             .save(output_path)
             .map_err(|e| format!("Failed to save image: {}", e))?;
 
-        Ok(format!("Filter applied successfully! 🎉 Saved to {}", output_path))
+        Ok(format!(
+            "Filter applied successfully! 🎉 Saved to {}",
+            output_path
+        ))
     }
 
     pub fn is_processing_done(&self) -> bool {
@@ -317,27 +327,26 @@ impl App {
 
         let path = PathBuf::from(&self.info_input);
         if !path.exists() {
-            self.status_message = "File not found! Silvestre couldn't find it either 🔍".to_string();
+            self.status_message =
+                "File not found! Silvestre couldn't find it either 🔍".to_string();
             return;
         }
 
         match ImageReader::open(&path) {
-            Ok(reader) => {
-                match reader.decode() {
-                    Ok(image) => {
-                        let width = image.width();
-                        let height = image.height();
-                        let color_type = format!("{:?}", image.color());
-                        self.status_message = format!(
-                            "📷 {}x{} {} (Silvestre approves ✓)",
-                            width, height, color_type
-                        );
-                    }
-                    Err(e) => {
-                        self.status_message = format!("Decode error: {} 🐱", e);
-                    }
+            Ok(reader) => match reader.decode() {
+                Ok(image) => {
+                    let width = image.width();
+                    let height = image.height();
+                    let color_type = format!("{:?}", image.color());
+                    self.status_message = format!(
+                        "📷 {}x{} {} (Silvestre approves ✓)",
+                        width, height, color_type
+                    );
                 }
-            }
+                Err(e) => {
+                    self.status_message = format!("Decode error: {} 🐱", e);
+                }
+            },
             Err(e) => {
                 self.status_message = format!("Read error: {} 🐱", e);
             }
@@ -469,8 +478,7 @@ impl App {
             self.status_message = "Check at least one filter before running 🐱".to_string();
             return;
         }
-        if self.pipeline_input_file.trim().is_empty()
-            || self.pipeline_output_file.trim().is_empty()
+        if self.pipeline_input_file.trim().is_empty() || self.pipeline_output_file.trim().is_empty()
         {
             self.status_message = "Please specify input and output files 🐱".to_string();
             return;
@@ -571,7 +579,11 @@ mod tests {
     /// return that path. `tag` keeps parallel tests from colliding.
     fn write_test_png(tag: &str, w: u32, h: u32) -> PathBuf {
         let mut path = std::env::temp_dir();
-        path.push(format!("silvestre_pipeline_{}_{}.png", std::process::id(), tag));
+        path.push(format!(
+            "silvestre_pipeline_{}_{}.png",
+            std::process::id(),
+            tag
+        ));
         let buffer = image::RgbaImage::from_pixel(w, h, image::Rgba([100, 150, 200, 255]));
         image::DynamicImage::ImageRgba8(buffer).save(&path).unwrap();
         path
@@ -579,7 +591,11 @@ mod tests {
 
     fn out_path(tag: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
-        path.push(format!("silvestre_pipeline_out_{}_{}.png", std::process::id(), tag));
+        path.push(format!(
+            "silvestre_pipeline_out_{}_{}.png",
+            std::process::id(),
+            tag
+        ));
         path
     }
 
@@ -594,12 +610,8 @@ mod tests {
         // and fails.
         let steps = vec![step("crop", "10,10,20,20"), step("resize", "5,5")];
 
-        let msg = run_pipeline(
-            input.to_str().unwrap(),
-            output.to_str().unwrap(),
-            &steps,
-        )
-        .expect("pipeline should succeed");
+        let msg = run_pipeline(input.to_str().unwrap(), output.to_str().unwrap(), &steps)
+            .expect("pipeline should succeed");
 
         assert!(msg.contains("2 step(s)"));
 
@@ -641,12 +653,8 @@ mod tests {
             step("invert", ""),
         ];
 
-        let err = run_pipeline(
-            input.to_str().unwrap(),
-            output.to_str().unwrap(),
-            &steps,
-        )
-        .unwrap_err();
+        let err =
+            run_pipeline(input.to_str().unwrap(), output.to_str().unwrap(), &steps).unwrap_err();
 
         assert!(err.contains("Step 2"), "error was: {}", err);
         assert!(err.contains("crop"), "error was: {}", err);
@@ -664,8 +672,12 @@ mod tests {
         // found" error from trying to open the (missing) file.
         let steps = vec![step("grayscale", ""), step("brightness", "notanumber")];
 
-        let err = run_pipeline("/no/such/validate_input.png", output.to_str().unwrap(), &steps)
-            .unwrap_err();
+        let err = run_pipeline(
+            "/no/such/validate_input.png",
+            output.to_str().unwrap(),
+            &steps,
+        )
+        .unwrap_err();
 
         assert!(err.contains("Step 2"), "error was: {}", err);
         assert!(!err.contains("not found"), "error was: {}", err);
@@ -696,7 +708,10 @@ mod tests {
     #[test]
     fn pipeline_list_mirrors_known_filters() {
         let app = App::new();
-        assert_eq!(app.pipeline_filters.len(), crate::filters::KNOWN_FILTERS.len());
+        assert_eq!(
+            app.pipeline_filters.len(),
+            crate::filters::KNOWN_FILTERS.len()
+        );
         // All start unchecked with empty params.
         assert!(app.pipeline_filters.iter().all(|f| !f.enabled));
         assert!(app.pipeline_filters.iter().all(|f| f.params.is_empty()));
@@ -743,7 +758,9 @@ mod tests {
 
         // Highlighted filter is disabled: typing is ignored.
         app.pipeline_input_char('9');
-        assert!(app.pipeline_filters[app.pipeline_selected].params.is_empty());
+        assert!(app.pipeline_filters[app.pipeline_selected]
+            .params
+            .is_empty());
 
         // Enable it, then typing edits its params.
         app.pipeline_toggle_selected();

--- a/silvestre-cli/src/filters.rs
+++ b/silvestre-cli/src/filters.rs
@@ -79,8 +79,8 @@ pub fn apply_named_filter(
         }
         "contrast" => {
             let factor = parse_f32(params, "Contrast requires a decimal number")?;
-            let filter = ContrastFilter::new(factor)
-                .map_err(|e| format!("Contrast filter error: {}", e))?;
+            let filter =
+                ContrastFilter::new(factor).map_err(|e| format!("Contrast filter error: {}", e))?;
             filter
                 .apply(img)
                 .map_err(|e| format!("Contrast filter error: {}", e))
@@ -133,8 +133,9 @@ pub fn silvestre_to_dynamic(img: &SilvestreImage) -> Result<image::DynamicImage,
     let pixels = img.pixels().to_vec();
 
     let dynamic = match img.color_space() {
-        ColorSpace::Rgba => image::RgbaImage::from_raw(w, h, pixels)
-            .map(image::DynamicImage::ImageRgba8),
+        ColorSpace::Rgba => {
+            image::RgbaImage::from_raw(w, h, pixels).map(image::DynamicImage::ImageRgba8)
+        }
         ColorSpace::Rgb => {
             image::RgbImage::from_raw(w, h, pixels).map(image::DynamicImage::ImageRgb8)
         }

--- a/silvestre-cli/src/main.rs
+++ b/silvestre-cli/src/main.rs
@@ -1,7 +1,7 @@
 mod app;
 mod filters;
-mod ui;
 mod handlers;
+mod ui;
 
 use app::App;
 use crossterm::{
@@ -26,10 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Restore terminal
     disable_raw_mode()?;
-    execute!(
-        std::io::stdout(),
-        LeaveAlternateScreen
-    )?;
+    execute!(std::io::stdout(), LeaveAlternateScreen)?;
 
     if let Err(err) = res {
         println!("Error: {}", err);
@@ -38,58 +35,48 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn run_app<B: Backend>(
-    mut terminal: Terminal<B>,
-    mut app: App,
-) -> Result<(), Box<dyn Error>> {
+fn run_app<B: Backend>(mut terminal: Terminal<B>, mut app: App) -> Result<(), Box<dyn Error>> {
     loop {
         terminal.draw(|f| ui::draw(f, &app))?;
 
         if crossterm::event::poll(std::time::Duration::from_millis(250))? {
             if let Event::Key(key) = event::read()? {
                 match app.current_screen {
-                    app::Screen::Main => {
-                        match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
-                            KeyCode::Char('f') => app.go_to_filter_menu(),
-                            KeyCode::Char('p') => app.go_to_pipeline(),
-                            KeyCode::Char('i') => app.go_to_info(),
-                            KeyCode::Char('h') => app.go_to_help(),
-                            _ => {}
-                        }
-                    }
-                    app::Screen::FilterMenu => {
-                        match key.code {
-                            KeyCode::Esc => app.go_to_main(),
-                            KeyCode::Up => app.select_previous_filter(),
-                            KeyCode::Down => app.select_next_filter(),
-                            KeyCode::Enter => app.go_to_apply_filter(),
-                            _ => {}
-                        }
-                    }
-                    app::Screen::ApplyFilter => {
-                        match key.code {
-                            KeyCode::Esc => app.go_to_main(),
-                            KeyCode::Tab => app.next_field(),
-                            KeyCode::BackTab => app.prev_field(),
-                            KeyCode::Char(c) => app.input_char(c),
-                            KeyCode::Backspace => app.input_backspace(),
-                            KeyCode::Enter => {
-                                if app.is_apply_button_focused() {
-                                    app.apply_filter_action();
-                                }
+                    app::Screen::Main => match key.code {
+                        KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                        KeyCode::Char('f') => app.go_to_filter_menu(),
+                        KeyCode::Char('p') => app.go_to_pipeline(),
+                        KeyCode::Char('i') => app.go_to_info(),
+                        KeyCode::Char('h') => app.go_to_help(),
+                        _ => {}
+                    },
+                    app::Screen::FilterMenu => match key.code {
+                        KeyCode::Esc => app.go_to_main(),
+                        KeyCode::Up => app.select_previous_filter(),
+                        KeyCode::Down => app.select_next_filter(),
+                        KeyCode::Enter => app.go_to_apply_filter(),
+                        _ => {}
+                    },
+                    app::Screen::ApplyFilter => match key.code {
+                        KeyCode::Esc => app.go_to_main(),
+                        KeyCode::Tab => app.next_field(),
+                        KeyCode::BackTab => app.prev_field(),
+                        KeyCode::Char(c) => app.input_char(c),
+                        KeyCode::Backspace => app.input_backspace(),
+                        KeyCode::Enter => {
+                            if app.is_apply_button_focused() {
+                                app.apply_filter_action();
                             }
-                            _ => {}
                         }
-                    }
+                        _ => {}
+                    },
                     app::Screen::Pipeline => {
                         // Ctrl-based chords drive actions so plain letters can
                         // still be typed into the focused params field.
                         let ctrl = key
                             .modifiers
                             .contains(crossterm::event::KeyModifiers::CONTROL);
-                        let on_filters =
-                            app.pipeline_field == app::PipelineField::Filters;
+                        let on_filters = app.pipeline_field == app::PipelineField::Filters;
                         match key.code {
                             KeyCode::Esc => app.go_to_main(),
                             KeyCode::Tab => app.pipeline_next_field(),
@@ -110,19 +97,16 @@ fn run_app<B: Backend>(
                             _ => {}
                         }
                     }
-                    app::Screen::Info => {
-                        match key.code {
-                            KeyCode::Esc => app.go_to_main(),
-                            KeyCode::Char(c) => app.info_input_char(c),
-                            KeyCode::Backspace => app.info_input_backspace(),
-                            KeyCode::Enter => app.load_image_info(),
-                            _ => {}
-                        }
-                    }
+                    app::Screen::Info => match key.code {
+                        KeyCode::Esc => app.go_to_main(),
+                        KeyCode::Char(c) => app.info_input_char(c),
+                        KeyCode::Backspace => app.info_input_backspace(),
+                        KeyCode::Enter => app.load_image_info(),
+                        _ => {}
+                    },
                     app::Screen::Help => {
-                        match key.code {
-                            KeyCode::Esc => app.go_to_main(),
-                            _ => {}
+                        if key.code == KeyCode::Esc {
+                            app.go_to_main()
                         }
                     }
                     app::Screen::Processing => {

--- a/silvestre-cli/src/main.rs
+++ b/silvestre-cli/src/main.rs
@@ -63,10 +63,8 @@ fn run_app<B: Backend>(mut terminal: Terminal<B>, mut app: App) -> Result<(), Bo
                         KeyCode::BackTab => app.prev_field(),
                         KeyCode::Char(c) => app.input_char(c),
                         KeyCode::Backspace => app.input_backspace(),
-                        KeyCode::Enter => {
-                            if app.is_apply_button_focused() {
-                                app.apply_filter_action();
-                            }
+                        KeyCode::Enter if app.is_apply_button_focused() => {
+                            app.apply_filter_action();
                         }
                         _ => {}
                     },

--- a/silvestre-cli/src/ui.rs
+++ b/silvestre-cli/src/ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, List, ListItem},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame,
 };
 
@@ -25,62 +25,109 @@ fn draw_main(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints([Constraint::Length(15), Constraint::Min(3), Constraint::Length(2)].as_ref())
+        .constraints(
+            [
+                Constraint::Length(15),
+                Constraint::Min(3),
+                Constraint::Length(2),
+            ]
+            .as_ref(),
+        )
         .split(f.area());
 
     // Title and welcome
     let title = vec![
+        Line::from(vec![Span::styled(
+            "╔════════════════════════════════════════╗",
+            Style::default().fg(Color::Cyan),
+        )]),
         Line::from(vec![
-            Span::styled("╔════════════════════════════════════════╗", Style::default().fg(Color::Cyan)),
+            Span::styled("║", Style::default().fg(Color::Cyan)),
+            Span::styled(
+                " 🐱 SILVESTRE - Image Processing CLI 🐱 ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("║", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
             Span::styled("║", Style::default().fg(Color::Cyan)),
-            Span::styled(" 🐱 SILVESTRE - Image Processing CLI 🐱 ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " (Named after my magnificent cat!)         ",
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::ITALIC),
+            ),
             Span::styled("║", Style::default().fg(Color::Cyan)),
         ]),
-        Line::from(vec![
-            Span::styled("║", Style::default().fg(Color::Cyan)),
-            Span::styled(" (Named after my magnificent cat!)         ", Style::default().fg(Color::Magenta).add_modifier(Modifier::ITALIC)),
-            Span::styled("║", Style::default().fg(Color::Cyan)),
-        ]),
-        Line::from(vec![
-            Span::styled("╚════════════════════════════════════════╝", Style::default().fg(Color::Cyan)),
-        ]),
+        Line::from(vec![Span::styled(
+            "╚════════════════════════════════════════╝",
+            Style::default().fg(Color::Cyan),
+        )]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("Welcome, fellow feline admirer! 🐾", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "Welcome, fellow feline admirer! 🐾",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )]),
     ];
 
     let menu = vec![
         Line::from(""),
         Line::from(vec![
             Span::raw("Press "),
-            Span::styled("f", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "f",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw(" to apply a "),
             Span::styled("filter", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
             Span::raw("Press "),
-            Span::styled("p", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "p",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw(" to build a filter "),
             Span::styled("pipeline", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
             Span::raw("Press "),
-            Span::styled("i", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "i",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw(" to inspect an "),
             Span::styled("image", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
             Span::raw("Press "),
-            Span::styled("h", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "h",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw(" for "),
             Span::styled("help", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
             Span::raw("Press "),
-            Span::styled("q", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "q",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::raw(" to "),
             Span::styled("quit", Style::default().fg(Color::Red)),
         ]),
@@ -310,7 +357,9 @@ fn draw_pipeline(f: &mut Frame, app: &App) {
                 if fi.params.is_empty() {
                     Span::styled(
                         format!("  {}", fi.hint),
-                        Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::ITALIC),
                     )
                 } else {
                     Span::styled(
@@ -326,12 +375,16 @@ fn draw_pipeline(f: &mut Frame, app: &App) {
             };
 
             let name_style = if fi.enabled {
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::Gray)
             };
             let check_style = if fi.enabled {
-                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::DarkGray)
             };
@@ -425,7 +478,14 @@ fn draw_info(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints([Constraint::Length(5), Constraint::Min(10), Constraint::Length(2)].as_ref())
+        .constraints(
+            [
+                Constraint::Length(5),
+                Constraint::Min(10),
+                Constraint::Length(2),
+            ]
+            .as_ref(),
+        )
         .split(f.area());
 
     // Input
@@ -472,13 +532,19 @@ fn draw_help(f: &mut Frame, app: &App) {
         .split(f.area());
 
     let help_text = vec![
-        Line::from(vec![
-            Span::styled("SILVESTRE - Image Processing CLI", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "SILVESTRE - Image Processing CLI",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("FILTERS", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "FILTERS",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from("  Brightness   - Adjust image brightness (requires delta parameter)"),
         Line::from("  Contrast     - Adjust image contrast (requires factor parameter)"),
         Line::from("  Grayscale    - Convert image to grayscale"),
@@ -488,26 +554,33 @@ fn draw_help(f: &mut Frame, app: &App) {
         Line::from("  Resize       - Change image dimensions (width, height)"),
         Line::from("  Rotate       - Rotate image by specified angle"),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("PIPELINE 🐾", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "PIPELINE 🐾",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from("  Press 'p' to chain multiple filters in one run."),
         Line::from("  Check the filters you want with Space and type any params"),
         Line::from("  next to them. Enabled filters run top→bottom, feeding each"),
         Line::from("  output into the next. Ctrl+R runs, Ctrl+X clears all."),
         Line::from("  A bad step reports which step number failed."),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("TIPS FROM SILVESTRE 🐱", Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "TIPS FROM SILVESTRE 🐱",
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from("  • Use Tab to navigate fields when applying filters"),
         Line::from("  • Press Esc to go back to the previous screen"),
         Line::from("  • The status bar shows helpful information"),
         Line::from("  • All operations are non-destructive on the original file"),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("Press Esc to return to main menu", Style::default().fg(Color::Green)),
-        ]),
+        Line::from(vec![Span::styled(
+            "Press Esc to return to main menu",
+            Style::default().fg(Color::Green),
+        )]),
     ];
 
     let help_block = Block::default()
@@ -533,9 +606,12 @@ fn draw_processing(f: &mut Frame, _app: &App) {
 
     let processing_text = vec![
         Line::from(""),
-        Line::from(vec![
-            Span::styled("Processing Image...", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "Processing Image...",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(""),
         Line::from("🐱 Silvestre is concentrating very hard... 😺"),
         Line::from(""),

--- a/silvestre-core/benches/filters.rs
+++ b/silvestre-core/benches/filters.rs
@@ -1,10 +1,11 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use silvestre_core::{
     effects::{BrightnessFilter, GrayscaleFilter, InvertFilter},
     filters::Filter,
-    transform::{ResizeFilter, Interpolation, MirrorFilter, MirrorMode},
+    transform::{Interpolation, MirrorFilter, MirrorMode, ResizeFilter},
     ColorSpace, SilvestreImage,
 };
+use std::hint::black_box;
 
 // Helper to create test images of various sizes
 fn create_test_image(width: u32, height: u32, color_space: ColorSpace) -> SilvestreImage {
@@ -78,21 +79,15 @@ fn bench_transforms(c: &mut Criterion) {
 
     // Resize benchmarks
     group.bench_function("resize_nearest_neighbor_100x100_to_50x50", |b| {
-        b.iter(|| {
-            ResizeFilter::new(50, 50, Interpolation::NearestNeighbor).apply(&img_100x100)
-        })
+        b.iter(|| ResizeFilter::new(50, 50, Interpolation::NearestNeighbor).apply(&img_100x100))
     });
 
     group.bench_function("resize_bilinear_100x100_to_200x200", |b| {
-        b.iter(|| {
-            ResizeFilter::new(200, 200, Interpolation::Bilinear).apply(&img_100x100)
-        })
+        b.iter(|| ResizeFilter::new(200, 200, Interpolation::Bilinear).apply(&img_100x100))
     });
 
     group.bench_function("resize_bilinear_512x512_to_256x256", |b| {
-        b.iter(|| {
-            ResizeFilter::new(256, 256, Interpolation::Bilinear).apply(&img_512x512)
-        })
+        b.iter(|| ResizeFilter::new(256, 256, Interpolation::Bilinear).apply(&img_512x512))
     });
 
     group.finish();

--- a/silvestre-core/src/analysis/histogram.rs
+++ b/silvestre-core/src/analysis/histogram.rs
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn solid_color_rgb_single_spike_per_channel() {
         // Solid red 2×2 image.
-        let pixels: Vec<u8> = vec![255, 0, 0].repeat(4);
+        let pixels: Vec<u8> = [255, 0, 0].repeat(4);
         let img = SilvestreImage::new(pixels, 2, 2, ColorSpace::Rgb).unwrap();
         let hist = Histogram::compute(&img);
         // Red channel spike at 255.

--- a/silvestre-core/src/effects/grayscale.rs
+++ b/silvestre-core/src/effects/grayscale.rs
@@ -108,9 +108,8 @@ mod tests {
     #[test]
     fn rgba_to_grayscale_ignores_alpha() {
         // Pure green with varying alpha: 0.587 * 255 = 149.685 -> 150
-        let img =
-            SilvestreImage::new(vec![0, 255, 0, 128, 0, 255, 0, 0], 2, 1, ColorSpace::Rgba)
-                .unwrap();
+        let img = SilvestreImage::new(vec![0, 255, 0, 128, 0, 255, 0, 0], 2, 1, ColorSpace::Rgba)
+            .unwrap();
         let out = to_grayscale(&img).unwrap();
         assert_eq!(out.pixels(), &[150, 150]);
     }

--- a/silvestre-core/src/effects/invert.rs
+++ b/silvestre-core/src/effects/invert.rs
@@ -40,8 +40,8 @@ pub fn invert(image: &SilvestreImage) -> Result<SilvestreImage> {
     let mut dst = image.pixels().to_vec();
 
     for pixel in dst.chunks_exact_mut(channels) {
-        for c in 0..colour_channels {
-            pixel[c] = 255 - pixel[c];
+        for channel in pixel.iter_mut().take(colour_channels) {
+            *channel = 255 - *channel;
         }
     }
 

--- a/silvestre-core/src/effects/sepia.rs
+++ b/silvestre-core/src/effects/sepia.rs
@@ -112,9 +112,15 @@ mod tests {
     // Helper: apply the sepia matrix to (r,g,b) and return (r_out, g_out, b_out).
     fn sepia_pixel(r: u8, g: u8, b: u8) -> (u8, u8, u8) {
         let (rf, gf, bf) = (f32::from(r), f32::from(g), f32::from(b));
-        let r_out = (0.393 * rf + 0.769 * gf + 0.189 * bf).round().clamp(0.0, 255.0) as u8;
-        let g_out = (0.349 * rf + 0.686 * gf + 0.168 * bf).round().clamp(0.0, 255.0) as u8;
-        let b_out = (0.272 * rf + 0.534 * gf + 0.131 * bf).round().clamp(0.0, 255.0) as u8;
+        let r_out = (0.393 * rf + 0.769 * gf + 0.189 * bf)
+            .round()
+            .clamp(0.0, 255.0) as u8;
+        let g_out = (0.349 * rf + 0.686 * gf + 0.168 * bf)
+            .round()
+            .clamp(0.0, 255.0) as u8;
+        let b_out = (0.272 * rf + 0.534 * gf + 0.131 * bf)
+            .round()
+            .clamp(0.0, 255.0) as u8;
         (r_out, g_out, b_out)
     }
 

--- a/silvestre-core/src/filters/box_blur.rs
+++ b/silvestre-core/src/filters/box_blur.rs
@@ -30,14 +30,14 @@ pub struct BoxBlurFilter {
 
 impl BoxBlurFilter {
     /// Create a new box blur filter with default border mode (Clamp).
-    /// 
+    ///
     /// Returns an error if the kernel cannot be created.
     pub fn new() -> Result<Self> {
         Self::with_border(BorderMode::Clamp)
     }
 
     /// Create a new box blur filter with a specific border mode.
-    /// 
+    ///
     /// Returns an error if the kernel cannot be created.
     pub fn with_border(border: BorderMode) -> Result<Self> {
         let coeffs = vec![1.0 / 3.0; 3];
@@ -121,17 +121,26 @@ mod tests {
 
     #[test]
     fn border_modes() {
-        let img = gray_image(3, 3, vec![0, 0, 0, 0, 255, 0, 0, 0, 0]);
-        
+        // A uniformly bright image distinguishes the border modes: `Clamp`
+        // replicates the bright edge so corners stay bright, while `Zero` pads
+        // with 0 and pulls the corners down. (An all-zero border, by contrast,
+        // makes the two modes identical, so it can't be used here.)
+        let img = gray_image(3, 3, vec![255; 9]);
+
         let filter_clamp = BoxBlurFilter::with_border(BorderMode::Clamp).unwrap();
         let out_clamp = filter_clamp.apply(&img).unwrap();
-        
+
         let filter_zero = BoxBlurFilter::with_border(BorderMode::Zero).unwrap();
         let out_zero = filter_zero.apply(&img).unwrap();
-        
-        // They should result in different values at the edges.
+
         assert_eq!(out_clamp.width(), 3);
         assert_eq!(out_zero.width(), 3);
+
+        // Clamp preserves the uniform brightness everywhere.
+        assert!(out_clamp.pixels().iter().all(|&v| v == 255));
+        // Zero darkens the edges (fewer in-bounds bright neighbors), so the
+        // two modes must differ.
         assert_ne!(out_clamp.pixels(), out_zero.pixels());
+        assert!(out_zero.pixels()[0] < 255);
     }
 }

--- a/silvestre-core/src/filters/canny.rs
+++ b/silvestre-core/src/filters/canny.rs
@@ -121,9 +121,7 @@ impl Filter for CannyFilter {
         let mut magnitude = vec![0.0_f32; len];
         let mut direction = vec![0.0_f32; len];
         for i in 0..len {
-            magnitude[i] = (gx[i] * gx[i] + gy[i] * gy[i])
-                .sqrt()
-                .clamp(0.0, 255.0);
+            magnitude[i] = (gx[i] * gx[i] + gy[i] * gy[i]).sqrt().clamp(0.0, 255.0);
             direction[i] = gy[i].atan2(gx[i]);
         }
 
@@ -173,7 +171,7 @@ fn normalize_angle(angle: f32) -> u8 {
     let a = if angle < 0.0 { angle + PI } else { angle };
     // Quantize: 0°=[0,22.5)∪[157.5,180), 45°=[22.5,67.5), 90°=[67.5,112.5), 135°=[112.5,157.5)
     let deg = a * 180.0 / PI;
-    if deg < 22.5 || deg >= 157.5 {
+    if !(22.5..157.5).contains(&deg) {
         0 // horizontal gradient -> compare left/right neighbors
     } else if deg < 67.5 {
         45
@@ -211,13 +209,7 @@ fn gradient_neighbors(angle: u8, x: usize, y: usize, width: usize) -> (usize, us
 /// Pixels above `high` are definite edges (255). Pixels below `low` are
 /// suppressed (0). Pixels between `low` and `high` are kept only if they
 /// are connected (8-connected) to a definite edge.
-fn hysteresis(
-    suppressed: &[f32],
-    width: usize,
-    height: usize,
-    low: f32,
-    high: f32,
-) -> Vec<u8> {
+fn hysteresis(suppressed: &[f32], width: usize, height: usize, low: f32, high: f32) -> Vec<u8> {
     let len = width * height;
     // 0 = suppressed, 1 = weak, 2 = strong
     let mut marker = vec![0u8; len];
@@ -260,7 +252,10 @@ fn hysteresis(
     }
 
     // Output: strong (promoted or original) = 255, everything else = 0.
-    marker.iter().map(|&m| if m == 2 { 255 } else { 0 }).collect()
+    marker
+        .iter()
+        .map(|&m| if m == 2 { 255 } else { 0 })
+        .collect()
 }
 
 #[cfg(test)]
@@ -365,7 +360,7 @@ mod tests {
         );
         // Exterior (well outside) should also be 0.
         assert_eq!(
-            out.pixels()[1 * 20 + 1],
+            out.pixels()[20 + 1],
             0,
             "exterior pixel should not be an edge"
         );
@@ -385,7 +380,9 @@ mod tests {
 
     #[test]
     fn accepts_rgba_input() {
-        let pixels = vec![255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 128, 128, 128, 255];
+        let pixels = vec![
+            255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 128, 128, 128, 255,
+        ];
         let img = SilvestreImage::new(pixels, 2, 2, ColorSpace::Rgba).unwrap();
         let canny = CannyFilter::new(20.0, 80.0, 1.0).unwrap();
         let out = canny.apply(&img).unwrap();
@@ -437,11 +434,8 @@ mod tests {
         // Manually test hysteresis: a strong pixel adjacent to weak pixels
         // should promote the weak ones.
         let suppressed = vec![
-            0.0, 0.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 40.0, 0.0, 0.0,
-            0.0, 40.0, 120.0, 40.0, 0.0,
-            0.0, 0.0, 40.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 40.0, 0.0, 0.0, 0.0, 40.0, 120.0, 40.0, 0.0, 0.0,
+            0.0, 40.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         ];
         let result = hysteresis(&suppressed, 5, 5, 30.0, 100.0);
         // Center (2,2) is strong (120 >= 100) -> 255.
@@ -451,7 +445,7 @@ mod tests {
         assert_eq!(result[11], 255); // (1,2)
         assert_eq!(result[13], 255); // (3,2)
         assert_eq!(result[17], 255); // (2,3)
-        // Far corners are 0.
+                                     // Far corners are 0.
         assert_eq!(result[0], 0);
         assert_eq!(result[24], 0);
     }
@@ -459,13 +453,12 @@ mod tests {
     #[test]
     fn weak_without_strong_neighbor_suppressed() {
         // All pixels are in the weak range but none are strong -> all suppressed.
-        let suppressed = vec![
-            0.0, 0.0, 0.0,
-            0.0, 60.0, 0.0,
-            0.0, 0.0, 0.0,
-        ];
+        let suppressed = vec![0.0, 0.0, 0.0, 0.0, 60.0, 0.0, 0.0, 0.0, 0.0];
         let result = hysteresis(&suppressed, 3, 3, 30.0, 100.0);
-        assert!(result.iter().all(|&v| v == 0), "isolated weak pixel should be suppressed");
+        assert!(
+            result.iter().all(|&v| v == 0),
+            "isolated weak pixel should be suppressed"
+        );
     }
 
     #[test]

--- a/silvestre-core/src/filters/gaussian.rs
+++ b/silvestre-core/src/filters/gaussian.rs
@@ -227,8 +227,7 @@ mod tests {
             }
         }
         let kernel_2d = Kernel::square(values_2d, size).unwrap();
-        let sep_kernel =
-            SeparableKernel::new(coeffs.clone(), coeffs).unwrap();
+        let sep_kernel = SeparableKernel::new(coeffs.clone(), coeffs).unwrap();
 
         let img = gray_image(8, 8, (0..64u8).collect());
 

--- a/silvestre-core/src/filters/median.rs
+++ b/silvestre-core/src/filters/median.rs
@@ -134,16 +134,11 @@ impl Filter for MedianFilter {
                     window.clear();
                     for ky in -half..=half {
                         for kx in -half..=half {
-                            let sample = match resolve_coord(
-                                x + kx,
-                                y + ky,
-                                width,
-                                height,
-                                self.border,
-                            ) {
-                                Some((sx, sy)) => src[sy * stride + sx * channels + c],
-                                None => 0,
-                            };
+                            let sample =
+                                match resolve_coord(x + kx, y + ky, width, height, self.border) {
+                                    Some((sx, sy)) => src[sy * stride + sx * channels + c],
+                                    None => 0,
+                                };
                             window.push(sample);
                         }
                     }

--- a/silvestre-core/src/filters/sharpen.rs
+++ b/silvestre-core/src/filters/sharpen.rs
@@ -30,24 +30,17 @@ pub struct SharpenFilter {
 
 impl SharpenFilter {
     /// Create a new sharpen filter with default border mode (Clamp).
-    /// 
+    ///
     /// Returns an error if the kernel cannot be created.
     pub fn new() -> Result<Self> {
         Self::with_border(BorderMode::Clamp)
     }
 
     /// Create a new sharpen filter with a specific border mode.
-    /// 
+    ///
     /// Returns an error if the kernel cannot be created.
     pub fn with_border(border: BorderMode) -> Result<Self> {
-        let kernel = Kernel::square(
-            vec![
-                 0.0, -1.0,  0.0,
-                -1.0,  5.0, -1.0,
-                 0.0, -1.0,  0.0,
-            ],
-            3,
-        )?;
+        let kernel = Kernel::square(vec![0.0, -1.0, 0.0, -1.0, 5.0, -1.0, 0.0, -1.0, 0.0], 3)?;
         Ok(Self { kernel, border })
     }
 }
@@ -75,7 +68,7 @@ mod tests {
         let img = SilvestreImage::new(pixels, 3, 3, ColorSpace::Grayscale).unwrap();
         let filter = SharpenFilter::new().unwrap();
         let out = filter.apply(&img).unwrap();
-        // The center pixel (200) has lower-valued neighbors (100). 
+        // The center pixel (200) has lower-valued neighbors (100).
         // Sharpening should push it higher.
         assert!(out.pixels()[4] > 200);
     }
@@ -96,9 +89,7 @@ mod tests {
     #[test]
     fn sharpen_rgb_image() {
         let pixels = vec![
-            0, 0, 0,  0, 0, 0,  0, 0, 0,
-            0, 0, 0,  100, 100, 100,  0, 0, 0,
-            0, 0, 0,  0, 0, 0,  0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         let img = SilvestreImage::new(pixels, 3, 3, ColorSpace::Rgb).unwrap();
         let filter = SharpenFilter::new().unwrap();
@@ -125,8 +116,14 @@ mod tests {
     fn sharpen_with_different_border_modes() {
         let pixels = vec![100; 9];
         let img = SilvestreImage::new(pixels, 3, 3, ColorSpace::Grayscale).unwrap();
-        let out_zero = SharpenFilter::with_border(BorderMode::Zero).unwrap().apply(&img).unwrap();
-        let out_clamp = SharpenFilter::with_border(BorderMode::Clamp).unwrap().apply(&img).unwrap();
+        let out_zero = SharpenFilter::with_border(BorderMode::Zero)
+            .unwrap()
+            .apply(&img)
+            .unwrap();
+        let out_clamp = SharpenFilter::with_border(BorderMode::Clamp)
+            .unwrap()
+            .apply(&img)
+            .unwrap();
         assert_ne!(out_zero.pixels(), out_clamp.pixels());
     }
 }

--- a/silvestre-core/src/filters/sobel.rs
+++ b/silvestre-core/src/filters/sobel.rs
@@ -83,10 +83,7 @@ impl Filter for SobelFilter {
 /// Each buffer has `width * height` elements in row-major order. The input
 /// **must** be a grayscale image with positive dimensions; the caller is
 /// responsible for validating this.
-pub(crate) fn sobel_gradients(
-    image: &SilvestreImage,
-    border: BorderMode,
-) -> (Vec<f32>, Vec<f32>) {
+pub(crate) fn sobel_gradients(image: &SilvestreImage, border: BorderMode) -> (Vec<f32>, Vec<f32>) {
     debug_assert_eq!(image.color_space(), ColorSpace::Grayscale);
     let width = image.width();
     let height = image.height();
@@ -254,7 +251,9 @@ mod tests {
         // With Clamp, all neighbors are 255, so gradients are 0.
         let img = gray_image(3, 3, vec![255; 9]);
         let clamp_out = SobelFilter::new().apply(&img).unwrap();
-        let zero_out = SobelFilter::with_border(BorderMode::Zero).apply(&img).unwrap();
+        let zero_out = SobelFilter::with_border(BorderMode::Zero)
+            .apply(&img)
+            .unwrap();
         assert_ne!(clamp_out.pixels(), zero_out.pixels());
     }
 
@@ -294,7 +293,10 @@ mod tests {
         let img = gray_image(4, 4, pixels);
         let out = SobelFilter::new().apply(&img).unwrap();
         let max = *out.pixels().iter().max().unwrap();
-        assert_eq!(max, 255, "edge pixels at full contrast should be clamped to 255");
+        assert_eq!(
+            max, 255,
+            "edge pixels at full contrast should be clamped to 255"
+        );
     }
 
     #[test]

--- a/silvestre-core/src/transform/crop.rs
+++ b/silvestre-core/src/transform/crop.rs
@@ -78,7 +78,12 @@ impl CropFilter {
     /// * `height` - Height of the crop region
     #[must_use]
     pub const fn new(x: u32, y: u32, width: u32, height: u32) -> Self {
-        Self { x, y, width, height }
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
     }
 
     /// The left coordinate of the crop region.
@@ -117,24 +122,22 @@ impl Filter for CropFilter {
 
         // Validate that crop region is within bounds
         let x_end = self.x.checked_add(self.width).ok_or_else(|| {
-            SilvestreError::InvalidParameter(
-                "crop x + width overflows u32".to_string(),
-            )
+            SilvestreError::InvalidParameter("crop x + width overflows u32".to_string())
         })?;
         let y_end = self.y.checked_add(self.height).ok_or_else(|| {
-            SilvestreError::InvalidParameter(
-                "crop y + height overflows u32".to_string(),
-            )
+            SilvestreError::InvalidParameter("crop y + height overflows u32".to_string())
         })?;
 
         if x_end > image.width() || y_end > image.height() {
-            return Err(SilvestreError::InvalidParameter(
-                format!(
-                    "crop region ({}, {}, {}, {}) exceeds image bounds ({}x{})",
-                    self.x, self.y, self.width, self.height,
-                    image.width(), image.height()
-                ),
-            ));
+            return Err(SilvestreError::InvalidParameter(format!(
+                "crop region ({}, {}, {}, {}) exceeds image bounds ({}x{})",
+                self.x,
+                self.y,
+                self.width,
+                self.height,
+                image.width(),
+                image.height()
+            )));
         }
 
         let channels = image.color_space().channels();
@@ -420,8 +423,8 @@ mod tests {
     #[test]
     fn crop_asymmetric_region() {
         let pixels = vec![
-            1, 2, 3, 4, 5,    // row 0
-            6, 7, 8, 9, 10,   // row 1
+            1, 2, 3, 4, 5, // row 0
+            6, 7, 8, 9, 10, // row 1
             11, 12, 13, 14, 15, // row 2
         ];
         let img = gray(5, 3, pixels);

--- a/silvestre-core/src/transform/mirror.rs
+++ b/silvestre-core/src/transform/mirror.rs
@@ -144,14 +144,18 @@ mod tests {
         //   row 0: 1 2 3
         //   row 1: 4 5 6
         let img = gray(3, 2, vec![1, 2, 3, 4, 5, 6]);
-        let out = MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap();
+        let out = MirrorFilter::new(MirrorMode::Horizontal)
+            .apply(&img)
+            .unwrap();
         assert_eq!(out.pixels(), &[3, 2, 1, 6, 5, 4]);
     }
 
     #[test]
     fn horizontal_single_column_is_identity() {
         let img = gray(1, 3, vec![10, 20, 30]);
-        let out = MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap();
+        let out = MirrorFilter::new(MirrorMode::Horizontal)
+            .apply(&img)
+            .unwrap();
         assert_eq!(out.pixels(), &[10, 20, 30]);
     }
 
@@ -222,7 +226,11 @@ mod tests {
         let img = gray(4, 3, pixels);
         let both = MirrorFilter::new(MirrorMode::Both).apply(&img).unwrap();
         let h_then_v = MirrorFilter::new(MirrorMode::Vertical)
-            .apply(&MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap())
+            .apply(
+                &MirrorFilter::new(MirrorMode::Horizontal)
+                    .apply(&img)
+                    .unwrap(),
+            )
             .unwrap();
         assert_eq!(both.pixels(), h_then_v.pixels());
     }
@@ -236,7 +244,9 @@ mod tests {
         // 2×1 RGBA: [R=255,G=0,B=0,A=255] | [R=0,G=255,B=0,A=255]
         let pixels = vec![255, 0, 0, 255, 0, 255, 0, 255];
         let img = SilvestreImage::new(pixels, 2, 1, ColorSpace::Rgba).unwrap();
-        let out = MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap();
+        let out = MirrorFilter::new(MirrorMode::Horizontal)
+            .apply(&img)
+            .unwrap();
         assert_eq!(out.pixels(), &[0, 255, 0, 255, 255, 0, 0, 255]);
     }
 
@@ -269,7 +279,9 @@ mod tests {
         //   4  5  6    =>    6  5  4
         //   7  8  9          9  8  7
         let img = gray(3, 3, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        let out = MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap();
+        let out = MirrorFilter::new(MirrorMode::Horizontal)
+            .apply(&img)
+            .unwrap();
         assert_eq!(out.get_pixel(0, 0).unwrap(), &[3]);
         assert_eq!(out.get_pixel(2, 0).unwrap(), &[1]);
         assert_eq!(out.get_pixel(0, 1).unwrap(), &[6]);
@@ -298,7 +310,11 @@ mod tests {
     #[test]
     fn preserves_dimensions_and_color_space() {
         let img = SilvestreImage::new(vec![0; 4 * 3 * 4], 4, 3, ColorSpace::Rgba).unwrap();
-        for mode in [MirrorMode::Horizontal, MirrorMode::Vertical, MirrorMode::Both] {
+        for mode in [
+            MirrorMode::Horizontal,
+            MirrorMode::Vertical,
+            MirrorMode::Both,
+        ] {
             let out = MirrorFilter::new(mode).apply(&img).unwrap();
             assert_eq!(out.width(), 4, "{mode:?}");
             assert_eq!(out.height(), 3, "{mode:?}");
@@ -313,7 +329,11 @@ mod tests {
     #[test]
     fn empty_image_is_preserved() {
         let img = gray(0, 0, vec![]);
-        for mode in [MirrorMode::Horizontal, MirrorMode::Vertical, MirrorMode::Both] {
+        for mode in [
+            MirrorMode::Horizontal,
+            MirrorMode::Vertical,
+            MirrorMode::Both,
+        ] {
             let out = MirrorFilter::new(mode).apply(&img).unwrap();
             assert_eq!(out.width(), 0, "{mode:?}");
             assert_eq!(out.height(), 0, "{mode:?}");
@@ -324,7 +344,11 @@ mod tests {
     #[test]
     fn single_pixel_is_identity() {
         let img = gray(1, 1, vec![42]);
-        for mode in [MirrorMode::Horizontal, MirrorMode::Vertical, MirrorMode::Both] {
+        for mode in [
+            MirrorMode::Horizontal,
+            MirrorMode::Vertical,
+            MirrorMode::Both,
+        ] {
             let out = MirrorFilter::new(mode).apply(&img).unwrap();
             assert_eq!(out.pixels(), &[42], "{mode:?}");
         }
@@ -333,7 +357,11 @@ mod tests {
     #[test]
     fn uniform_image_unchanged_by_any_mode() {
         let img = gray(4, 4, vec![128; 16]);
-        for mode in [MirrorMode::Horizontal, MirrorMode::Vertical, MirrorMode::Both] {
+        for mode in [
+            MirrorMode::Horizontal,
+            MirrorMode::Vertical,
+            MirrorMode::Both,
+        ] {
             let out = MirrorFilter::new(mode).apply(&img).unwrap();
             assert!(out.pixels().iter().all(|&v| v == 128), "{mode:?}");
         }

--- a/silvestre-core/src/transform/resize.rs
+++ b/silvestre-core/src/transform/resize.rs
@@ -180,7 +180,12 @@ impl Filter for ResizeFilter {
             }
         }
 
-        SilvestreImage::new(dst, self.target_width, self.target_height, image.color_space())
+        SilvestreImage::new(
+            dst,
+            self.target_width,
+            self.target_height,
+            image.color_space(),
+        )
     }
 }
 
@@ -282,8 +287,14 @@ mod tests {
         // source, showing that blending occurred.
         let center_tl = out.get_pixel(1, 1).unwrap()[0];
         let center_tr = out.get_pixel(2, 1).unwrap()[0];
-        assert!(center_tl < 255 && center_tl > 0, "expected blending at (1,1), got {center_tl}");
-        assert!(center_tr < 255 && center_tr > 0, "expected blending at (2,1), got {center_tr}");
+        assert!(
+            center_tl < 255 && center_tl > 0,
+            "expected blending at (1,1), got {center_tl}"
+        );
+        assert!(
+            center_tr < 255 && center_tr > 0,
+            "expected blending at (2,1), got {center_tr}"
+        );
     }
 
     #[test]
@@ -354,8 +365,7 @@ mod tests {
     #[test]
     fn nearest_upscale_rgb() {
         // 1×1 RGB image → 2×2
-        let img =
-            SilvestreImage::new(vec![100, 150, 200], 1, 1, ColorSpace::Rgb).unwrap();
+        let img = SilvestreImage::new(vec![100, 150, 200], 1, 1, ColorSpace::Rgb).unwrap();
         let out = ResizeFilter::new(2, 2, Interpolation::NearestNeighbor)
             .apply(&img)
             .unwrap();
@@ -363,14 +373,16 @@ mod tests {
         assert_eq!(out.height(), 2);
         assert_eq!(out.color_space(), ColorSpace::Rgb);
         // Every pixel must equal the single source pixel.
-        assert_eq!(out.pixels(), &[100, 150, 200, 100, 150, 200, 100, 150, 200, 100, 150, 200]);
+        assert_eq!(
+            out.pixels(),
+            &[100, 150, 200, 100, 150, 200, 100, 150, 200, 100, 150, 200]
+        );
     }
 
     #[test]
     fn bilinear_upscale_rgba_preserves_channels() {
         // 1×1 RGBA → 2×2; all output pixels equal the single source pixel.
-        let img =
-            SilvestreImage::new(vec![10, 20, 30, 255], 1, 1, ColorSpace::Rgba).unwrap();
+        let img = SilvestreImage::new(vec![10, 20, 30, 255], 1, 1, ColorSpace::Rgba).unwrap();
         let out = ResizeFilter::new(2, 2, Interpolation::Bilinear)
             .apply(&img)
             .unwrap();
@@ -477,7 +489,8 @@ mod tests {
 
     #[test]
     fn filter_trait_object_nearest() {
-        let filter: Box<dyn Filter> = Box::new(ResizeFilter::new(2, 2, Interpolation::NearestNeighbor));
+        let filter: Box<dyn Filter> =
+            Box::new(ResizeFilter::new(2, 2, Interpolation::NearestNeighbor));
         let img = gray(1, 1, vec![42]);
         let out = filter.apply(&img).unwrap();
         assert_eq!(out.width(), 2);

--- a/silvestre-core/src/transform/rotate.rs
+++ b/silvestre-core/src/transform/rotate.rs
@@ -181,7 +181,15 @@ impl RotateFilter {
     }
 
     /// Bilinear interpolation for sampling a source image at fractional coordinates.
-    fn bilinear_sample(src: &[u8], src_w: usize, src_h: usize, x: f64, y: f64, channels: usize, channel_idx: usize) -> u8 {
+    fn bilinear_sample(
+        src: &[u8],
+        src_w: usize,
+        src_h: usize,
+        x: f64,
+        y: f64,
+        channels: usize,
+        channel_idx: usize,
+    ) -> u8 {
         let x = x.max(0.0).min(src_w as f64 - 1.0);
         let y = y.max(0.0).min(src_h as f64 - 1.0);
 
@@ -202,7 +210,7 @@ impl RotateFilter {
         let bottom = v01 * (1.0 - fx) + v11 * fx;
         let value = top * (1.0 - fy) + bottom * fy;
 
-        (value.round().max(0.0).min(255.0)) as u8
+        value.round().clamp(0.0, 255.0) as u8
     }
 
     /// Get background color value for a single channel based on color space.
@@ -251,7 +259,8 @@ impl RotateFilter {
                     }
                 } else {
                     for c in 0..channels {
-                        let value = Self::bilinear_sample(src, src_w, src_h, src_x, src_y, channels, c);
+                        let value =
+                            Self::bilinear_sample(src, src_w, src_h, src_x, src_y, channels, c);
                         dst[(dst_y * src_w + dst_x) * channels + c] = value;
                     }
                 }
@@ -276,7 +285,9 @@ mod tests {
     fn rotate_0_degrees_returns_clone() {
         let pixels = vec![1, 2, 3, 4, 5, 6];
         let img = gray(3, 2, pixels.clone());
-        let rotated = RotateFilter::new(0.0, 255, [255, 255, 255]).apply(&img).unwrap();
+        let rotated = RotateFilter::new(0.0, 255, [255, 255, 255])
+            .apply(&img)
+            .unwrap();
         assert_eq!(rotated.pixels(), &pixels);
         assert_eq!(rotated.width(), img.width());
         assert_eq!(rotated.height(), img.height());
@@ -286,7 +297,9 @@ mod tests {
     fn rotate_360_degrees_returns_clone() {
         let pixels = vec![1, 2, 3, 4, 5, 6];
         let img = gray(3, 2, pixels.clone());
-        let rotated = RotateFilter::new(360.0, 255, [255, 255, 255]).apply(&img).unwrap();
+        let rotated = RotateFilter::new(360.0, 255, [255, 255, 255])
+            .apply(&img)
+            .unwrap();
         assert_eq!(rotated.pixels(), &pixels);
     }
 
@@ -294,7 +307,9 @@ mod tests {
     fn rotate_negative_angle_normalizes() {
         let pixels = vec![1, 2, 3, 4];
         let img = gray(2, 2, pixels.clone());
-        let rotated = RotateFilter::new(-360.0, 255, [255, 255, 255]).apply(&img).unwrap();
+        let rotated = RotateFilter::new(-360.0, 255, [255, 255, 255])
+            .apply(&img)
+            .unwrap();
         assert_eq!(rotated.pixels(), &pixels);
     }
 
@@ -547,9 +562,7 @@ mod tests {
     fn rotate_arbitrary_small_angle() {
         let pixels: Vec<u8> = (0..16).collect();
         let img = gray(4, 4, pixels);
-        let rotated = RotateFilter::new(5.0, 0, [0, 0, 0])
-            .apply(&img)
-            .unwrap();
+        let rotated = RotateFilter::new(5.0, 0, [0, 0, 0]).apply(&img).unwrap();
         assert_eq!(rotated.width(), 4);
         assert_eq!(rotated.height(), 4);
         let rotated_pixels = rotated.pixels();
@@ -565,9 +578,7 @@ mod tests {
     #[test]
     fn rotate_arbitrary_background_grayscale() {
         let img = gray(2, 2, vec![100; 4]);
-        let rotated = RotateFilter::new(45.0, 0, [0, 0, 0])
-            .apply(&img)
-            .unwrap();
+        let rotated = RotateFilter::new(45.0, 0, [0, 0, 0]).apply(&img).unwrap();
         assert_eq!(rotated.get_pixel(0, 0).unwrap(), &[0]);
     }
 
@@ -653,14 +664,13 @@ mod tests {
             .apply(&img)
             .unwrap();
         let center = rotated.get_pixel(2, 2).unwrap()[0];
-        assert!(center >= 145 && center <= 155);
+        assert!((145..=155).contains(&center));
     }
 
     #[test]
     fn rotate_arbitrary_rgba_preserves_alpha() {
         let pixels = vec![
-            255, 0, 0, 255,    0, 255, 0, 255,
-            0, 0, 255, 255,    255, 255, 0, 255,
+            255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
         ];
         let img = SilvestreImage::new(pixels, 2, 2, ColorSpace::Rgba).unwrap();
         let rotated = RotateFilter::new(30.0, 255, [128, 128, 128])

--- a/silvestre-core/tests/integration_test.rs
+++ b/silvestre-core/tests/integration_test.rs
@@ -94,7 +94,9 @@ fn test_mirror_round_trip() {
     let img = create_test_image(12, 12, ColorSpace::Rgb);
 
     // Mirror horizontally twice should be identity
-    let h_flip = MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap();
+    let h_flip = MirrorFilter::new(MirrorMode::Horizontal)
+        .apply(&img)
+        .unwrap();
     let h_flip_again = MirrorFilter::new(MirrorMode::Horizontal)
         .apply(&h_flip)
         .unwrap();
@@ -147,7 +149,9 @@ fn test_1x1_image_operations() {
     let _ = BrightnessFilter::new(50).apply(&img).unwrap();
     let _ = GrayscaleFilter.apply(&img).unwrap();
     let _ = InvertFilter.apply(&img).unwrap();
-    let _ = MirrorFilter::new(MirrorMode::Horizontal).apply(&img).unwrap();
+    let _ = MirrorFilter::new(MirrorMode::Horizontal)
+        .apply(&img)
+        .unwrap();
 }
 
 #[test]
@@ -187,11 +191,7 @@ fn test_large_image_operations() {
 
 #[test]
 fn test_all_color_spaces() {
-    for color_space in [
-        ColorSpace::Grayscale,
-        ColorSpace::Rgb,
-        ColorSpace::Rgba,
-    ] {
+    for color_space in [ColorSpace::Grayscale, ColorSpace::Rgb, ColorSpace::Rgba] {
         let img = create_test_image(8, 8, color_space);
 
         // Test that basic operations preserve color space

--- a/silvestre-core/tests/property_tests.rs
+++ b/silvestre-core/tests/property_tests.rs
@@ -9,12 +9,19 @@ use silvestre_core::{
 };
 
 // Strategy for generating valid images
-fn arb_image(max_width: u32, max_height: u32) -> impl Strategy<Value = (u32, u32, ColorSpace, Vec<u8>)> {
-    (1..=max_width, 1..=max_height, Just(ColorSpace::Grayscale))
-        .prop_flat_map(|(w, h, cs)| {
-            let len = (w as usize) * (h as usize) * cs.channels();
-            (Just(w), Just(h), Just(cs), prop::collection::vec(0u8..=255, len..=len))
-        })
+fn arb_image(
+    max_width: u32,
+    max_height: u32,
+) -> impl Strategy<Value = (u32, u32, ColorSpace, Vec<u8>)> {
+    (1..=max_width, 1..=max_height, Just(ColorSpace::Grayscale)).prop_flat_map(|(w, h, cs)| {
+        let len = (w as usize) * (h as usize) * cs.channels();
+        (
+            Just(w),
+            Just(h),
+            Just(cs),
+            prop::collection::vec(0u8..=255, len..=len),
+        )
+    })
 }
 
 proptest! {

--- a/silvestre-ffi/src/lib.rs
+++ b/silvestre-ffi/src/lib.rs
@@ -474,13 +474,9 @@ fn apply_named_filter(
         "resize" => {
             let w = parse_param_u32(params, "w")?;
             let h = parse_param_u32(params, "h")?;
-            ResizeFilter::new(
-                w,
-                h,
-                silvestre_core::transform::Interpolation::Bilinear,
-            )
-            .apply(image)
-            .map_err(|e| e.to_string())
+            ResizeFilter::new(w, h, silvestre_core::transform::Interpolation::Bilinear)
+                .apply(image)
+                .map_err(|e| e.to_string())
         }
         "rotate" => {
             let angle = parse_param_f64(params, "angle")?;
@@ -536,8 +532,7 @@ fn extract_json_value(json: &str, key: &str) -> Result<String, String> {
     };
 
     // If the value is a quoted string
-    if after_colon.starts_with('"') {
-        let content = &after_colon[1..];
+    if let Some(content) = after_colon.strip_prefix('"') {
         let end = content
             .find('"')
             .ok_or_else(|| format!("unterminated string for parameter: {key}"))?;
@@ -546,7 +541,7 @@ fn extract_json_value(json: &str, key: &str) -> Result<String, String> {
 
     // Otherwise it's a number/boolean — take until comma, brace, or end.
     let end = after_colon
-        .find(|c: char| c == ',' || c == '}' || c == ']')
+        .find([',', '}', ']'])
         .unwrap_or(after_colon.len());
 
     let value = after_colon[..end].trim();
@@ -607,8 +602,7 @@ mod tests {
             0, 0, 255, 255, // blue
             255, 255, 0, 255, // yellow
         ];
-        let ptr =
-            unsafe { silvestre_image_from_buffer(pixels.as_ptr(), pixels.len(), 2, 2) };
+        let ptr = unsafe { silvestre_image_from_buffer(pixels.as_ptr(), pixels.len(), 2, 2) };
         assert!(!ptr.is_null(), "failed to create test image");
         ptr
     }
@@ -648,8 +642,7 @@ mod tests {
     #[test]
     fn test_image_from_buffer_size_mismatch() {
         let pixels: Vec<u8> = vec![0; 4]; // 4 bytes but asking for 2x2 (needs 16)
-        let img =
-            unsafe { silvestre_image_from_buffer(pixels.as_ptr(), pixels.len(), 2, 2) };
+        let img = unsafe { silvestre_image_from_buffer(pixels.as_ptr(), pixels.len(), 2, 2) };
         assert!(img.is_null());
         let err = silvestre_last_error();
         assert!(!err.is_null());
@@ -692,7 +685,7 @@ mod tests {
             assert!(!p.is_null());
             let len = silvestre_image_pixels_len(img);
             assert_eq!(len, 16); // 2*2*4
-            // First pixel is red
+                                 // First pixel is red
             assert_eq!(*p, 255);
             assert_eq!(*p.add(1), 0);
             assert_eq!(*p.add(2), 0);
@@ -706,9 +699,7 @@ mod tests {
     #[test]
     fn test_save_null_image() {
         let path = CString::new("/tmp/test.png").unwrap();
-        let rc = unsafe {
-            silvestre_image_save(ptr::null(), path.as_ptr(), ptr::null())
-        };
+        let rc = unsafe { silvestre_image_save(ptr::null(), path.as_ptr(), ptr::null()) };
         assert_eq!(rc, ERR);
     }
 
@@ -765,8 +756,7 @@ mod tests {
     #[test]
     fn test_apply_filter_null_image() {
         let name = CString::new("grayscale").unwrap();
-        let rc =
-            unsafe { silvestre_apply_filter(ptr::null_mut(), name.as_ptr(), ptr::null()) };
+        let rc = unsafe { silvestre_apply_filter(ptr::null_mut(), name.as_ptr(), ptr::null()) };
         assert_eq!(rc, ERR);
     }
 

--- a/silvestre_flutter/example/.gitignore
+++ b/silvestre_flutter/example/.gitignore
@@ -85,6 +85,15 @@ unlinked_spec.ds
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 
+# macOS (generated / ephemeral — must not be committed)
+**/macos/Flutter/ephemeral/
+**/macos/Flutter/GeneratedPluginRegistrant.swift
+**/xcuserdata/
+
+# Windows (generated / ephemeral)
+**/windows/flutter/ephemeral/
+**/windows/flutter/generated_plugin*
+
 # Coverage
 coverage/
 

--- a/silvestre_flutter/rust/src/api/filters.rs
+++ b/silvestre_flutter/rust/src/api/filters.rs
@@ -46,8 +46,7 @@ pub fn apply_filter(
     let params: serde_json::Value = if params_json.is_empty() {
         serde_json::Value::Object(serde_json::Map::new())
     } else {
-        serde_json::from_str(&params_json)
-            .map_err(|e| format!("invalid JSON params: {e}"))?
+        serde_json::from_str(&params_json).map_err(|e| format!("invalid JSON params: {e}"))?
     };
 
     let result = apply_named_filter(&name, &img.inner, &params)?;
@@ -131,13 +130,9 @@ fn apply_named_filter(
         "resize" => {
             let w = get_u32(params, "w")?;
             let h = get_u32(params, "h")?;
-            ResizeFilter::new(
-                w,
-                h,
-                silvestre_core::transform::Interpolation::Bilinear,
-            )
-            .apply(image)
-            .map_err(|e| e.to_string())
+            ResizeFilter::new(w, h, silvestre_core::transform::Interpolation::Bilinear)
+                .apply(image)
+                .map_err(|e| e.to_string())
         }
         "rotate" => {
             let angle = get_f64(params, "angle")?;

--- a/silvestre_flutter/rust/src/api/image.rs
+++ b/silvestre_flutter/rust/src/api/image.rs
@@ -68,11 +68,7 @@ pub fn image_pixels(img: &SilvestreImageWrapper) -> Vec<u8> {
 /// Save the image to a file path in the specified format.
 ///
 /// `format` must be one of: `"png"`, `"jpeg"` / `"jpg"`, `"bmp"`.
-pub fn save_image(
-    img: &SilvestreImageWrapper,
-    path: String,
-    format: String,
-) -> Result<(), String> {
+pub fn save_image(img: &SilvestreImageWrapper, path: String, format: String) -> Result<(), String> {
     let fmt = parse_format(&format)?;
     img.inner
         .save_with_format(&path, fmt)

--- a/silvestre_flutter/rust/src/lib.rs
+++ b/silvestre_flutter/rust/src/lib.rs
@@ -1,2 +1,2 @@
-mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 pub mod api;
+mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml`, which runs on every push to `main` and every PR:

- **lint** — `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings`.
- **test** — matrix over **Linux, macOS, and Windows**: builds the workspace, runs `cargo test --workspace` (lib + doc tests across every crate), and builds `silvestre-cli`.
- **wasm** — `wasm-pack build --target web`.
- **flutter** — builds the Rust bridge crate, then `dart format --check`, `flutter analyze`, and `flutter test` for the plugin and its example app.

Cargo dependencies are cached with `Swatinem/rust-cache`, and in-progress runs are cancelled per ref (`concurrency`) to keep total wall-clock time well under 15 minutes.

To make CI **green from the first run**, this PR also fixes the existing issues it would otherwise surface:

- Reformatted the whole workspace with `cargo fmt` (the bulk of the diff).
- Fixed every `clippy` warning: deprecated `criterion::black_box`, manual range/`clamp` patterns, an index-only loop, and manual prefix-strip / char-compare in the FFI.
- Fixed the `box_blur::border_modes` test, which asserted `Clamp` and `Zero` produce different output but used an all-zero border — a case where the two modes are provably identical. It now uses a uniformly bright image that genuinely distinguishes them.
- Ignored the Flutter macOS/Windows `ephemeral/` generated files (they hardcode machine-specific paths and must never be committed).

Adds a CI status badge to the README.

Closes #35

## Test plan

Verified locally (the exact commands CI runs):

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo build --workspace` (with `RUSTFLAGS=-D warnings`) — builds
- [x] `cargo test --workspace` — all pass (core 310 lib + 33 doc, cli 24, ffi 46, integration/property)
- [x] `cargo build --target wasm32-unknown-unknown -p silvestre-wasm` — builds
- [x] `flutter analyze` + `flutter test` for plugin and example — clean (18 example tests)
- [x] `dart format --set-exit-if-changed lib` — clean
- [ ] CI goes green on GitHub (verified once the workflow runs on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added continuous integration to run formatting checks, linting, tests, WebAssembly builds, and Flutter validation (including an example APK build) across major platforms.
  * Added a CI status badge to the README.
  * Expanded Flutter example ignore rules and added analyzer exclusions for generated build output.
* **Refactor**
  * Improved code formatting and readability across the command-line UI, core filters/transforms, and Flutter bindings, preserving behavior.
* **Tests**
  * Strengthened and reformatted unit/property/integration coverage for filters and edge cases (e.g., mirroring and border handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->